### PR TITLE
✨ add support for import and export of a main crypto key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ coverage/
 
 # ide
 .idea
+.vscode
 

--- a/distribution/key.js
+++ b/distribution/key.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.KEYTYPES = exports.exportPublicKeyToSPKI = exports.importPublicKeyFromSPKI = exports.exportPrivateKeyToPKCS8 = exports.importPrivateKeyFromPKCS8 = exports.exportSymKeyToHexadecimal = exports.exportSymKeyToBase64 = exports.importSymKeyFromBase64 = exports.exportKey = exports.importKey = exports.generateSymKey = exports.generateAsymKeyPair = exports.deriveKey = void 0;
+exports.KEYTYPES = exports.exportPublicKeyToSPKI = exports.importPublicKeyFromSPKI = exports.exportPrivateKeyToPKCS8 = exports.importPrivateKeyFromPKCS8 = exports.importSymKeyFromHexadecimal = exports.exportSymKeyToHexadecimal = exports.exportSymKeyToBase64 = exports.importSymKeyFromBase64 = exports.exportKey = exports.importKey = exports.generateSymKey = exports.generateAsymKeyPair = exports.deriveKey = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
@@ -210,8 +210,24 @@ var importSymKeyFromBase64 = function importSymKeyFromBase64(base64Key) {
   var algorithm = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _algorithms.AES_GCM;
   return crypto.subtle.importKey('raw', (0, _utils.convertBase64ToArrayBufferView)(base64Key), algorithm, false, [ENCRYPT, DECRYPT]);
 };
+/**
+ * Import from hexadecimal encoded raw key to CryptoKey.
+ * An imported key should never be extractable.
+ *
+ * @param {String} hexadecimal - hexadecimal encoded key
+ * @param algorithm - cryptographic algorithm
+ * @returns {Promise} Resolves to the key as a CryptoKey.
+ */
+
 
 exports.importSymKeyFromBase64 = importSymKeyFromBase64;
+
+var importSymKeyFromHexadecimal = function importSymKeyFromHexadecimal(hexadecimal) {
+  var algorithm = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _algorithms.AES_GCM;
+  crypto.subtle.importKey('raw', (0, _utils.convertHexadecimalToArrayBuffer)(hexadecimal), algorithm, false, [ENCRYPT, DECRYPT]);
+};
+
+exports.importSymKeyFromHexadecimal = importSymKeyFromHexadecimal;
 
 var importKey = function importKey(key) {
   switch (key.t) {
@@ -231,6 +247,9 @@ var importKey = function importKey(key) {
     case KEYTYPES.USER.PUBLIC_KEY:
     case KEYTYPES.APP.PUBLIC_KEY:
       return importPublicKeyFromSPKI(key.pub);
+
+    case KEYTYPES.MAIN_KEY:
+      return importSymKeyFromHexadecimal(key.sym);
 
     default:
       throw new Error('invalid key type');

--- a/distribution/key.js
+++ b/distribution/key.js
@@ -153,7 +153,13 @@ var exportKey = function exportKey(key, type) {
       });
 
     case KEYTYPES.MAIN_KEY:
-      return exportSymKeyToHexadecimal(key);
+      return exportSymKeyToHexadecimal(key).then(function (hexadecimal) {
+        return {
+          t: type,
+          v: KEYVERSION,
+          sym: hexadecimal
+        };
+      });
 
     default:
       throw new Error("invalid key type: ".concat(type));

--- a/distribution/key.js
+++ b/distribution/key.js
@@ -224,7 +224,7 @@ exports.importSymKeyFromBase64 = importSymKeyFromBase64;
 
 var importSymKeyFromHexadecimal = function importSymKeyFromHexadecimal(hexadecimal) {
   var algorithm = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _algorithms.AES_GCM;
-  return crypto.subtle.importKey('raw', (0, _utils.convertHexadecimalToArrayBuffer)(hexadecimal), algorithm, false, [ENCRYPT, DECRYPT]);
+  return crypto.subtle.importKey('raw', (0, _utils.convertHexadecimalToArrayBuffer)(hexadecimal), algorithm, false, [DECRYPT]);
 };
 
 exports.importSymKeyFromHexadecimal = importSymKeyFromHexadecimal;

--- a/distribution/key.js
+++ b/distribution/key.js
@@ -224,7 +224,7 @@ exports.importSymKeyFromBase64 = importSymKeyFromBase64;
 
 var importSymKeyFromHexadecimal = function importSymKeyFromHexadecimal(hexadecimal) {
   var algorithm = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _algorithms.AES_GCM;
-  crypto.subtle.importKey('raw', (0, _utils.convertHexadecimalToArrayBuffer)(hexadecimal), algorithm, false, [ENCRYPT, DECRYPT]);
+  return crypto.subtle.importKey('raw', (0, _utils.convertHexadecimalToArrayBuffer)(hexadecimal), algorithm, false, [ENCRYPT, DECRYPT]);
 };
 
 exports.importSymKeyFromHexadecimal = importSymKeyFromHexadecimal;

--- a/distribution/key.js
+++ b/distribution/key.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.KEYTYPES = exports.exportPublicKeyToSPKI = exports.importPublicKeyFromSPKI = exports.exportPrivateKeyToPKCS8 = exports.importPrivateKeyFromPKCS8 = exports.exportSymKeyToBase64 = exports.importSymKeyFromBase64 = exports.exportKey = exports.importKey = exports.generateSymKey = exports.generateAsymKeyPair = exports.deriveKey = void 0;
+exports.KEYTYPES = exports.exportPublicKeyToSPKI = exports.importPublicKeyFromSPKI = exports.exportPrivateKeyToPKCS8 = exports.importPrivateKeyFromPKCS8 = exports.exportSymKeyToHexadecimal = exports.exportSymKeyToBase64 = exports.importSymKeyFromBase64 = exports.exportKey = exports.importKey = exports.generateSymKey = exports.generateAsymKeyPair = exports.deriveKey = void 0;
 
 require("core-js/modules/es7.symbol.async-iterator");
 
@@ -43,6 +43,7 @@ var DECRYPT = 'decrypt';
 var KEYTYPES = {
   COMMON_KEY: 'ck',
   DATA_KEY: 'dk',
+  MAIN_KEY: 'mk',
   PASSWORD_KEY: 'pk',
   ATTACHMENT_KEY: 'ak',
   TAG_ENCRYPTION_KEY: 'tek',
@@ -100,8 +101,21 @@ var exportPrivateKeyToPKCS8 = function exportPrivateKeyToPKCS8(cryptoKey) {
     return new Uint8Array(PKCS8);
   }).then(_utils.convertArrayBufferViewToBase64);
 };
+/**
+ * Export symmetric CryptoKey as hexadecimal raw key
+ *
+ * @param {Object} cryptoKey - the cryptoKey that should be exported
+ * @returns {Promise} Resolves to the key as a hexadecimal encoded String.
+ */
+
 
 exports.exportPrivateKeyToPKCS8 = exportPrivateKeyToPKCS8;
+
+var exportSymKeyToHexadecimal = function exportSymKeyToHexadecimal(cryptoKey) {
+  return crypto.subtle.exportKey('raw', cryptoKey).then(_utils.convertArrayBufferToHexadecimal);
+};
+
+exports.exportSymKeyToHexadecimal = exportSymKeyToHexadecimal;
 
 var exportKey = function exportKey(key, type) {
   switch (type) {
@@ -137,6 +151,9 @@ var exportKey = function exportKey(key, type) {
           pub: base64
         };
       });
+
+    case KEYTYPES.MAIN_KEY:
+      return exportSymKeyToHexadecimal(key);
 
     default:
       throw new Error("invalid key type: ".concat(type));

--- a/distribution/utils.js
+++ b/distribution/utils.js
@@ -3,7 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.isEdge = exports.mergeUint8Arrays = exports.convertBlobToArrayBufferView = exports.convertObjectToArrayBufferView = exports.convertArrayBufferViewToBase64 = exports.convertBase64ToArrayBufferView = exports.convertArrayBufferViewToString = exports.convertStringToArrayBufferView = void 0;
+exports.isEdge = exports.mergeUint8Arrays = exports.convertBlobToArrayBufferView = exports.convertObjectToArrayBufferView = exports.convertArrayBufferToHexadecimal = exports.convertArrayBufferViewToBase64 = exports.convertBase64ToArrayBufferView = exports.convertArrayBufferViewToString = exports.convertStringToArrayBufferView = void 0;
+
+require("core-js/modules/es6.regexp.to-string");
+
+require("core-js/modules/es7.string.pad-start");
+
+require("core-js/modules/es6.string.iterator");
+
+require("core-js/modules/es6.array.from");
 
 require("core-js/modules/es6.typed.uint8-array");
 
@@ -67,9 +75,25 @@ var mergeUint8Arrays = function mergeUint8Arrays(arr1, arr2) {
   merge.set(arr1);
   merge.set(arr2, arr1.length);
   return merge;
-}; // this does not affect Chrome-based Edge because its user agent only contains "Edg"
+};
+/**
+ * converts an ArrayBuffer to a hexadecimal string
+ *
+ * @param {ArrayBuffer} buffer
+ * @returns {String} - hexadecimal representation of the ArrayBuffer
+ *
+ */
 
 
 exports.mergeUint8Arrays = mergeUint8Arrays;
+
+var convertArrayBufferToHexadecimal = function convertArrayBufferToHexadecimal(buffer) {
+  return Array.from(new Uint8Array(buffer)).map(function (x) {
+    return x.toString(16).padStart(2, '0');
+  }).join('');
+}; // this does not affect Chrome-based Edge because its user agent only contains "Edg"
+
+
+exports.convertArrayBufferToHexadecimal = convertArrayBufferToHexadecimal;
 var isEdge = window.navigator.userAgent.indexOf('Edge') > -1;
 exports.isEdge = isEdge;

--- a/distribution/utils.js
+++ b/distribution/utils.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.isEdge = exports.mergeUint8Arrays = exports.convertBlobToArrayBufferView = exports.convertObjectToArrayBufferView = exports.convertArrayBufferToHexadecimal = exports.convertArrayBufferViewToBase64 = exports.convertBase64ToArrayBufferView = exports.convertArrayBufferViewToString = exports.convertStringToArrayBufferView = void 0;
+exports.isEdge = exports.mergeUint8Arrays = exports.convertBlobToArrayBufferView = exports.convertObjectToArrayBufferView = exports.convertHexadecimalToArrayBuffer = exports.convertArrayBufferToHexadecimal = exports.convertArrayBufferViewToBase64 = exports.convertBase64ToArrayBufferView = exports.convertArrayBufferViewToString = exports.convertStringToArrayBufferView = void 0;
 
 require("core-js/modules/es6.regexp.to-string");
 
@@ -91,9 +91,34 @@ var convertArrayBufferToHexadecimal = function convertArrayBufferToHexadecimal(b
   return Array.from(new Uint8Array(buffer)).map(function (x) {
     return x.toString(16).padStart(2, '0');
   }).join('');
-}; // this does not affect Chrome-based Edge because its user agent only contains "Edg"
+};
+/**
+ * converts a hexadecimal string to an ArrayBuffer
+ *
+ * @param {String} hexadecimal
+ * @returns {Uint8Array} - the bytes of the hexadecimal string
+ *
+ */
 
 
 exports.convertArrayBufferToHexadecimal = convertArrayBufferToHexadecimal;
+
+var convertHexadecimalToArrayBuffer = function convertHexadecimalToArrayBuffer(hexadecimal) {
+  if (typeof hexadecimal !== 'string') {
+    throw new TypeError('Expected input to be a string');
+  }
+
+  if (hexadecimal.length % 2 !== 0) {
+    throw new RangeError('Expected string to be an even number of characters');
+  }
+
+  var output = new Uint8Array(Math.ceil(hexadecimal.length / 2)).map(function (x, i) {
+    return parseInt(hexadecimal.substr(i * 2, 2), 16);
+  });
+  return output.buffer;
+}; // this does not affect Chrome-based Edge because its user agent only contains "Edg"
+
+
+exports.convertHexadecimalToArrayBuffer = convertHexadecimalToArrayBuffer;
 var isEdge = window.navigator.userAgent.indexOf('Edge') > -1;
 exports.isEdge = isEdge;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d4l/js-crypto",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "The Data4Life JavaScript crypto library used for performing crypto operations using the native Web Crypto API.",
   "main": "distribution/index.js",
   "scripts": {

--- a/source/key.js
+++ b/source/key.js
@@ -104,7 +104,11 @@ const exportKey = (key, type) => {
                 pub: base64,
             }));
     case KEYTYPES.MAIN_KEY:
-        return exportSymKeyToHexadecimal(key);
+        return exportSymKeyToHexadecimal(key).then(hexadecimal => ({
+            t: type,
+            v: KEYVERSION,
+            sym: hexadecimal,
+        }));
     default:
         throw new Error(`invalid key type: ${type}`);
     }

--- a/source/key.js
+++ b/source/key.js
@@ -7,6 +7,7 @@ import {
     convertArrayBufferViewToString,
     convertArrayBufferToHexadecimal,
     convertBase64ToArrayBufferView,
+    convertHexadecimalToArrayBuffer,
 } from './utils';
 
 const KEYVERSION = 1;
@@ -165,6 +166,23 @@ const importSymKeyFromBase64 = (base64Key, algorithm = AES_GCM) =>
         [ENCRYPT, DECRYPT],
     );
 
+/**
+ * Import from hexadecimal encoded raw key to CryptoKey.
+ * An imported key should never be extractable.
+ *
+ * @param {String} hexadecimal - hexadecimal encoded key
+ * @param algorithm - cryptographic algorithm
+ * @returns {Promise} Resolves to the key as a CryptoKey.
+ */
+const importSymKeyFromHexadecimal = (hexadecimal, algorithm = AES_GCM) =>
+    crypto.subtle.importKey(
+        'raw',
+        convertHexadecimalToArrayBuffer(hexadecimal),
+        algorithm,
+        false,
+        [ENCRYPT, DECRYPT],
+    );
+
 const importKey = (key) => {
     switch (key.t) {
     case KEYTYPES.COMMON_KEY:
@@ -180,6 +198,8 @@ const importKey = (key) => {
     case KEYTYPES.USER.PUBLIC_KEY:
     case KEYTYPES.APP.PUBLIC_KEY:
         return importPublicKeyFromSPKI(key.pub);
+    case KEYTYPES.MAIN_KEY:
+        return importSymKeyFromHexadecimal(key.sym);
     default:
         throw new Error('invalid key type');
     }
@@ -302,6 +322,7 @@ export {
     importSymKeyFromBase64,
     exportSymKeyToBase64,
     exportSymKeyToHexadecimal,
+    importSymKeyFromHexadecimal,
     importPrivateKeyFromPKCS8,
     exportPrivateKeyToPKCS8,
     importPublicKeyFromSPKI,

--- a/source/key.js
+++ b/source/key.js
@@ -1,14 +1,11 @@
 import pbkdf2 from 'pbkdf2';
 
-import {
-    AES_CBC,
-    AES_GCM,
-    RSA_OAEP,
-} from './algorithms';
+import { AES_CBC, AES_GCM, RSA_OAEP } from './algorithms';
 import {
     isEdge,
     convertArrayBufferViewToBase64,
     convertArrayBufferViewToString,
+    convertArrayBufferToHexadecimal,
     convertBase64ToArrayBufferView,
 } from './utils';
 
@@ -19,6 +16,7 @@ const DECRYPT = 'decrypt';
 const KEYTYPES = {
     COMMON_KEY: 'ck',
     DATA_KEY: 'dk',
+    MAIN_KEY: 'mk',
     PASSWORD_KEY: 'pk',
     ATTACHMENT_KEY: 'ak',
     TAG_ENCRYPTION_KEY: 'tek',
@@ -45,7 +43,6 @@ const exportPublicKeyToSPKI = cryptoKey =>
         .then(SPKI => new Uint8Array(SPKI))
         .then(convertArrayBufferViewToBase64);
 
-
 /**
  * Export symmetric CryptoKey as base64 encoded raw key.
  *
@@ -56,7 +53,6 @@ const exportSymKeyToBase64 = cryptoKey =>
     crypto.subtle.exportKey('raw', cryptoKey)
         .then(byteKey => new Uint8Array(byteKey))
         .then(convertArrayBufferViewToBase64);
-
 
 /**
  * Export private CryptoKey to base64 encoded PKCS8.
@@ -69,6 +65,14 @@ const exportPrivateKeyToPKCS8 = cryptoKey =>
         .then(PKCS8 => new Uint8Array(PKCS8))
         .then(convertArrayBufferViewToBase64);
 
+/**
+ * Export symmetric CryptoKey as hexadecimal raw key
+ *
+ * @param {Object} cryptoKey - the cryptoKey that should be exported
+ * @returns {Promise} Resolves to the key as a hexadecimal encoded String.
+ */
+const exportSymKeyToHexadecimal = cryptoKey =>
+    crypto.subtle.exportKey('raw', cryptoKey).then(convertArrayBufferToHexadecimal);
 
 const exportKey = (key, type) => {
     switch (type) {
@@ -99,6 +103,8 @@ const exportKey = (key, type) => {
                 v: KEYVERSION,
                 pub: base64,
             }));
+    case KEYTYPES.MAIN_KEY:
+        return exportSymKeyToHexadecimal(key);
     default:
         throw new Error(`invalid key type: ${type}`);
     }
@@ -121,7 +127,6 @@ const importPrivateKeyFromPKCS8 = PKCS8 =>
         [DECRYPT],
     );
 
-
 /**
  * Import public CryptoKey from base64 encoded SPKI.
  *
@@ -139,7 +144,6 @@ const importPublicKeyFromSPKI = (SPKI) => {
     );
 };
 
-
 /**
  * Import from base64 encoded raw key to CryptoKey.
  * An imported key should never be extractable.
@@ -156,7 +160,6 @@ const importSymKeyFromBase64 = (base64Key, algorithm = AES_GCM) =>
         false,
         [ENCRYPT, DECRYPT],
     );
-
 
 const importKey = (key) => {
     switch (key.t) {
@@ -177,7 +180,6 @@ const importKey = (key) => {
         throw new Error('invalid key type');
     }
 };
-
 
 // GENERATE
 
@@ -264,7 +266,6 @@ const deriveKey = (masterKey, salt = new Uint8Array(16), algorithm = AES_GCM) =>
         .then(key => exportKey(key, KEYTYPES.PASSWORD_KEY));
 };
 
-
 /**
  * Creates a random public-private key pair
  * @param {String} type - type of the key pair 'A' for App, 'U' for User
@@ -288,24 +289,18 @@ const generateAsymKeyPair = type =>
         ]))
         .then(([publicKey, privateKey]) => ({ publicKey, privateKey }));
 
-
 export {
     deriveKey,
-
     generateAsymKeyPair,
     generateSymKey,
-
     importKey,
     exportKey,
-
     importSymKeyFromBase64,
     exportSymKeyToBase64,
-
+    exportSymKeyToHexadecimal,
     importPrivateKeyFromPKCS8,
     exportPrivateKeyToPKCS8,
-
     importPublicKeyFromSPKI,
     exportPublicKeyToSPKI,
-
     KEYTYPES,
 };

--- a/source/key.js
+++ b/source/key.js
@@ -180,7 +180,7 @@ const importSymKeyFromHexadecimal = (hexadecimal, algorithm = AES_GCM) =>
         convertHexadecimalToArrayBuffer(hexadecimal),
         algorithm,
         false,
-        [ENCRYPT, DECRYPT],
+        [DECRYPT],
     );
 
 const importKey = (key) => {

--- a/source/utils.js
+++ b/source/utils.js
@@ -55,6 +55,29 @@ const convertArrayBufferToHexadecimal = buffer => Array.from(new Uint8Array(buff
     .map(x => x.toString(16).padStart(2, '0'))
     .join('');
 
+
+/**
+ * converts a hexadecimal string to an ArrayBuffer
+ *
+ * @param {String} hexadecimal
+ * @returns {Uint8Array} - the bytes of the hexadecimal string
+ *
+ */
+const convertHexadecimalToArrayBuffer = (hexadecimal) => {
+    if (typeof hexadecimal !== 'string') {
+        throw new TypeError('Expected input to be a string');
+    }
+
+    if ((hexadecimal.length % 2) !== 0) {
+        throw new RangeError('Expected string to be an even number of characters');
+    }
+
+    const output = new Uint8Array(Math.ceil(hexadecimal.length / 2))
+        .map((x, i) => parseInt(hexadecimal.substr(i * 2, 2), 16));
+
+    return output.buffer;
+};
+
 // this does not affect Chrome-based Edge because its user agent only contains "Edg"
 const isEdge = window.navigator.userAgent.indexOf('Edge') > -1;
 
@@ -64,6 +87,7 @@ export {
     convertBase64ToArrayBufferView,
     convertArrayBufferViewToBase64,
     convertArrayBufferToHexadecimal,
+    convertHexadecimalToArrayBuffer,
     convertObjectToArrayBufferView,
     convertBlobToArrayBufferView,
     mergeUint8Arrays,

--- a/source/utils.js
+++ b/source/utils.js
@@ -37,7 +37,6 @@ const convertBlobToArrayBufferView = blob =>
         fileReader.readAsArrayBuffer(blob);
     });
 
-
 const mergeUint8Arrays = (arr1, arr2) => {
     const merge = new Uint8Array(arr1.length + arr2.length);
     merge.set(arr1);
@@ -45,19 +44,28 @@ const mergeUint8Arrays = (arr1, arr2) => {
     return merge;
 };
 
+/**
+ * converts an ArrayBuffer to a hexadecimal string
+ *
+ * @param {ArrayBuffer} buffer
+ * @returns {String} - hexadecimal representation of the ArrayBuffer
+ *
+ */
+const convertArrayBufferToHexadecimal = buffer => Array.from(new Uint8Array(buffer))
+    .map(x => x.toString(16).padStart(2, '0'))
+    .join('');
+
 // this does not affect Chrome-based Edge because its user agent only contains "Edg"
 const isEdge = window.navigator.userAgent.indexOf('Edge') > -1;
 
 export {
     convertStringToArrayBufferView,
     convertArrayBufferViewToString,
-
     convertBase64ToArrayBufferView,
     convertArrayBufferViewToBase64,
-
+    convertArrayBufferToHexadecimal,
     convertObjectToArrayBufferView,
     convertBlobToArrayBufferView,
-
     mergeUint8Arrays,
     isEdge,
 };

--- a/test/key.js
+++ b/test/key.js
@@ -19,6 +19,8 @@ import {
     masterKeyArray,
     IV,
     masterKey,
+    symMainKey,
+    symMainCryptoKey,
     symCommonKey,
     symCommonCryptoKey,
     symCommonKeyJWK,
@@ -175,6 +177,19 @@ describe('key.js', () => {
                     expect(JSON.stringify(cryptoKey.algorithm))
                         .to.deep.equal(JSON.stringify(asymPrivateCryptoKey.algorithm));
                     expect(cryptoKey.usages).to.deep.equal(asymPrivateCryptoKey.usages);
+
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('is able to import a main key (sym, AES-GCM)', (done) => {
+            importKey(symMainKey)
+                .then((cryptoKey) => {
+                    expect(cryptoKey.type).to.equal(symMainCryptoKey.type);
+                    expect(cryptoKey.extractable).to.equal(symMainCryptoKey.extractable);
+                    expect(cryptoKey.algorithm).to.deep.equal(symMainCryptoKey.algorithm);
+                    expect(cryptoKey.usages).to.deep.equal(symMainCryptoKey.usages);
 
                     done();
                 })

--- a/test/testResources/crypto.js
+++ b/test/testResources/crypto.js
@@ -2,6 +2,7 @@ const plainText = 'Hęłlø črüėl wōrlđ';
 const plainArray = new Uint8Array([72, 196, 153, 197, 130, 108, 195, 184, 32, 196, 141, 114, 195,
     188, 196, 151, 108, 32, 119, 197, 141, 114, 108, 196, 145]);
 const plainBase64 = 'SMSZxYJsw7ggxI1yw7zEl2wgd8WNcmzEkQ==';
+const plainHexadecimal = '48c499c5826cc3b820c48d72c3bcc4976c2077c58d726cc491';
 
 // plainText encrypted with tagEncryptionKey
 const cipherTextArray = new Uint8Array([171, 91, 91, 132, 110, 103, 148, 58, 71, 118, 97, 228, 246,
@@ -51,6 +52,7 @@ export {
     plainText,
     plainArray,
     plainBase64,
+    plainHexadecimal,
     cipherTextArray,
     cipherTextBase64,
     plainObject,

--- a/test/testResources/key.js
+++ b/test/testResources/key.js
@@ -14,6 +14,18 @@ const masterKey = {
     sym: 'nlBTQFK5rgG3YviH1xXckALC77mZ5IPe+FEGSIBF8KI=',
 };
 
+const symMainKey = {
+    t: 'mk',
+    v: 1,
+    sym: '498f0615b8a30b14da0bac84b52d41655fcc6876f20f0929e6cef74d4ce63082',
+};
+const symMainCryptoKey = {
+    type: 'secret',
+    extractable: false,
+    algorithm: { name: 'AES-GCM', length: 256 },
+    usages: ['encrypt', 'decrypt'],
+};
+
 const symCommonKey = {
     t: 'ck',
     v: 1,
@@ -114,6 +126,8 @@ export {
     defaultMasterKey,
     IV,
     masterKey,
+    symMainKey,
+    symMainCryptoKey,
     symCommonKey,
     symCommonCryptoKey,
     symCommonKeyJWK,

--- a/test/testResources/key.js
+++ b/test/testResources/key.js
@@ -23,7 +23,7 @@ const symMainCryptoKey = {
     type: 'secret',
     extractable: false,
     algorithm: { name: 'AES-GCM', length: 256 },
-    usages: ['encrypt', 'decrypt'],
+    usages: ['decrypt'],
 };
 
 const symCommonKey = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -96,14 +96,16 @@ describe('utils.js', () => {
             try {
                 convertHexadecimalToArrayBuffer(123);
             } catch (error) {
+                expect(error.name).to.eql('TypeError');
                 expect(error.message).to.eql('Expected input to be a string');
             }
         });
 
-        it('should return a TypeError if the input is not a string', () => {
+        it('should return a RangeError if the input is not an even number of characters', () => {
             try {
                 convertHexadecimalToArrayBuffer(plainHexadecimal.substr(1));
             } catch (error) {
+                expect(error.name).to.eql('RangeError');
                 expect(error.message).to.eql('Expected string to be an even number of characters');
             }
         });

--- a/test/utils.js
+++ b/test/utils.js
@@ -91,5 +91,21 @@ describe('utils.js', () => {
             expect(convertHexadecimalToArrayBuffer(plainHexadecimal))
                 .to.deep.equal(plainArray.buffer);
         });
+
+        it('should return a TypeError if the input is not a string', () => {
+            try {
+                convertHexadecimalToArrayBuffer(123);
+            } catch (error) {
+                expect(error.message).to.eql('Expected input to be a string');
+            }
+        });
+
+        it('should return a TypeError if the input is not a string', () => {
+            try {
+                convertHexadecimalToArrayBuffer(plainHexadecimal.substr(1));
+            } catch (error) {
+                expect(error.message).to.eql('Expected string to be an even number of characters');
+            }
+        });
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -14,6 +14,7 @@ import {
     convertBlobToArrayBufferView,
 
     convertArrayBufferToHexadecimal,
+    convertHexadecimalToArrayBuffer,
 
     mergeUint8Arrays,
 } from '../source/utils';
@@ -82,6 +83,13 @@ describe('utils.js', () => {
     describe('convertArrayBufferToHexadecimal', () => {
         it('should properly convert ArrayBuffer to hexadecimal', () => {
             expect(convertArrayBufferToHexadecimal(plainArray)).to.deep.equal(plainHexadecimal);
+        });
+    });
+
+    describe('convertHexadecimalToArrayBuffer', () => {
+        it('should properly convert hexadecimal to ArrayBuffer', () => {
+            expect(convertHexadecimalToArrayBuffer(plainHexadecimal))
+                .to.deep.equal(plainArray.buffer);
         });
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -13,6 +13,8 @@ import {
 
     convertBlobToArrayBufferView,
 
+    convertArrayBufferToHexadecimal,
+
     mergeUint8Arrays,
 } from '../source/utils';
 
@@ -20,6 +22,7 @@ import {
     plainText,
     plainArray,
     plainBase64,
+    plainHexadecimal,
     plainObject,
     plainObjectArray,
     plainBlob,
@@ -73,6 +76,12 @@ describe('utils.js', () => {
         it('should merge ArrayBuffers properly', () => {
             const mergedArray = mergeUint8Arrays(plainArray, plainArray);
             expect(convertArrayBufferViewToString(mergedArray)).to.equal(plainText + plainText);
+        });
+    });
+
+    describe('convertArrayBufferToHexadecimal', () => {
+        it('should properly convert ArrayBuffer to hexadecimal', () => {
+            expect(convertArrayBufferToHexadecimal(plainArray)).to.deep.equal(plainHexadecimal);
         });
     });
 });


### PR DESCRIPTION
## Description

The following PR introduces the following changes:

- new util method for converting a Crypto Key ArrayBuffer to a hexadecimal string `convertArrayBufferToHexadecimal`
- new util method for converting a hexadecimal string to a Crypto Key ArrayBuffer `convertHexadecimalToArrayBuffer`
- new key type `MAIN_KEY`
- method for exporting a symmetric CryptoKey as hexadecimal raw key `exportSymKeyToHexadecimal`
- method for importing a symmetric `MAIN_KEY` represented as hexadecimal `importSymKeyFromHexadecimal`

## Issue Link

https://gesundheitscloud.atlassian.net/browse/CIT-3889


## Due diligence checklist

- [x] Code is formatted according to the agreed rules.
- [x] Added unit tests.
- [x] Updated `package.json` version.

CC: @stefantds (since I cannot add you as a reviewer).