### PR TITLE
Allow a main key object to be exportable

### DIFF
--- a/source/key.js
+++ b/source/key.js
@@ -168,7 +168,6 @@ const importSymKeyFromBase64 = (base64Key, algorithm = AES_GCM) =>
 
 /**
  * Import from hexadecimal encoded raw key to CryptoKey.
- * An imported key should never be extractable.
  *
  * @param {String} hexadecimal - hexadecimal encoded key
  * @param algorithm - cryptographic algorithm
@@ -179,7 +178,7 @@ const importSymKeyFromHexadecimal = (hexadecimal, algorithm = AES_GCM) =>
         'raw',
         convertHexadecimalToArrayBuffer(hexadecimal),
         algorithm,
-        false,
+        true,
         [DECRYPT, ENCRYPT],
     );
 


### PR DESCRIPTION
There is a mixup in the current code between the import key operation and the web-crypto unexportable key notion. Our import functions mainly allow to create a web crypto key from a d4l key. If we want the wb-crypto key to be exportable or not otally depends on the context of the usage.
Ideally we would split these concepts but currently our import functions are the only way to deserialise a d4l key (besides the generation functions).